### PR TITLE
feat: add template for secrets when create/modify a gist

### DIFF
--- a/templates/base/secret.html
+++ b/templates/base/secret.html
@@ -1,0 +1,10 @@
+{{ define "secret" }}
+<div
+  class="p-4 max-w-md mx-auto bg-white rounded-xl shadow-lg flex items-center my-4">
+  <div>
+    <p class="text-rose-600/75">
+      <strong>Remember: </strong>Never store sensitive information here!
+    </p>
+  </div>
+</div>
+{{ end }}

--- a/templates/pages/create.html
+++ b/templates/pages/create.html
@@ -1,4 +1,5 @@
 {{ template "header" .}}
+{{ template "secret" .}}
 <div class="py-10">
     <header>
 
@@ -8,6 +9,7 @@
 
     </header>
     <main class="mt-4">
+        
         <form id="create" class="space-y-4" method="post" action="{{ $.c.ExternalUrl }}/">
             <div>
                 <p class="cursor-pointer select-none" id="gist-metadata-btn">Metadata ▼</p>

--- a/templates/pages/edit.html
+++ b/templates/pages/edit.html
@@ -1,4 +1,5 @@
 {{ template "header" .}}
+{{ template "secret" .}}
 <div class="py-10">
     <header>
         <div class="flex flex-col lg:flex-row">
@@ -7,6 +8,7 @@
                     {{ .locale.Tr "gist.edit.editing" }} {{ .gist.Title }}
                 </h1>
             </div>
+           
             <div class="lg:flex-row flex py-2 lg:py-0 lg:ml-auto">
                 <form id="visibility" class="flex items-center whitespace-nowrap" method="post" action="{{ $.c.ExternalUrl }}/{{ .gist.User.Username }}/{{ .gist.Identifier }}/visibility">
                     {{ .csrfHtml }}


### PR DESCRIPTION
asana: https://app.asana.com/0/1208258146672219/1208258146672227/f

Added a new banner when create or edit a gist to make sure end user is warned about storing sensitive informations 

<img width="1177" alt="Screenshot 2024-09-09 at 11 46 12" src="https://github.com/user-attachments/assets/15a2d918-0d22-46d0-a150-b9e3c340ecda">
<img width="1121" alt="Screenshot 2024-09-09 at 11 46 01" src="https://github.com/user-attachments/assets/909010db-4c8a-4f52-8c0e-7f52ff7cdaf8">
